### PR TITLE
convert method name to camelCase

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -35,7 +35,12 @@ class PrettyPrinter extends ResultPrinter implements TestListener
 
         preg_match_all('/((?:^|[A-Z])[a-z]+)/', $testMethodName[1], $matches);
         $testNameArray = array_map('strtolower', $matches[0]);
-        array_shift($testNameArray);
+
+        // check if prefix is test remove it
+        if ($testNameArray[0] === 'test') {
+            array_shift($testNameArray);
+        }
+
         $name = implode(' ', $testNameArray);
 
         $color = 'fg-green';

--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -29,8 +29,11 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         parent::endTest($test, $time);
 
         $testMethodName = explode('::', \PHPUnit\Util\Test::describe($test));
-        preg_match_all('/((?:^|[A-Z])[a-z]+)/', $testMethodName[1], $matches);
 
+        // convert snakeCase method name to camelCase
+        $testMethodName[1] = str_replace('_', '', ucwords($testMethodName[1], '_'));
+
+        preg_match_all('/((?:^|[A-Z])[a-z]+)/', $testMethodName[1], $matches);
         $testNameArray = array_map('strtolower', $matches[0]);
         array_shift($testNameArray);
         $name = implode(' ', $testNameArray);


### PR DESCRIPTION
Some developers prefer snake case to method name of the test unit, so this cause print class output empty method name as result.

This PR force converts snake case to camelCase before split method name.

Thanks