### PR TITLE
Fix error $e variable not exists

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -84,8 +84,8 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         while ($exception) {
             $this->write(
                 "\nCaused by\n" .
-                TestFailure::exceptionToString($e) . "\n" .
-                Filter::getFilteredStacktrace($e)
+                TestFailure::exceptionToString($exception) . "\n" .
+                Filter::getFilteredStacktrace($exception)
             );
             $exception = $exception->getPrevious();
         }


### PR DESCRIPTION
I suppose it was old variable name which wasn't updated over time