### PR TITLE
Add PHP 7.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable" : true,
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "phpunit/phpunit": ">=6.0.0"
     },
     "autoload": {

--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -14,17 +14,17 @@ class PrettyPrinter extends ResultPrinter implements TestListener
     protected $className;
     protected $previousClassName;
 
-    public function startTestSuite(TestSuite $suite)
+    public function startTestSuite(TestSuite $suite): void
     {
         parent::startTestSuite($suite);
     }
 
-    public function startTest(Test $test)
+    public function startTest(Test $test): void
     {
         $this->className = get_class($test);
     }
 
-    public function endTest(Test $test, $time)
+    public function endTest(Test $test, $time): void
     {
         parent::endTest($test, $time);
 
@@ -56,7 +56,7 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         $this->writeWithColor($timeColor, '[' . number_format($time, 3) . 's]', true);
     }
 
-    protected function writeProgress($progress)
+    protected function writeProgress($progress): void
     {
         if ($this->previousClassName !== $this->className) {
             $this->write("\n");
@@ -73,7 +73,7 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         }
     }
 
-    protected function printDefectTrace(TestFailure $defect)
+    protected function printDefectTrace(TestFailure $defect): void
     {
         $this->write($this->formatExceptionMsg($defect->getExceptionAsString()));
         $trace = Filter::getFilteredStacktrace(
@@ -93,7 +93,7 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         }
     }
 
-    protected function formatExceptionMsg($exceptionMessage)
+    protected function formatExceptionMsg($exceptionMessage): string
     {
         $exceptionMessage = str_replace("+++ Actual\n", '', $exceptionMessage);
         $exceptionMessage = str_replace("--- Expected\n", '', $exceptionMessage);


### PR DESCRIPTION
Adds return type-hints which make this compatible when running PHP >=7.1 environments. Most of the PHP 7 installs are running at least 7.1 as this version added quite a bit of functionality on top of the performance improvements introduced in 7.0
  
Should fix #8