### PR TITLE
Make compatible with PHPUnit 7.1

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -56,7 +56,7 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         $this->writeWithColor($timeColor, '[' . number_format($time, 3) . 's]', true);
     }
 
-    protected function writeProgress($progress): void
+    protected function writeProgress(string $progress): void
     {
         if ($this->previousClassName !== $this->className) {
             $this->write("\n");


### PR DESCRIPTION
This makes the printer compatible with PHPUnit 7.1, but will still be backwards compatible to previous PHPUnit versions.

Refs https://github.com/sempro/phpunit-pretty-print/issues/13