### PR TITLE
Support non-breaking spaces in function names.

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -31,6 +31,9 @@ class PrettyPrinter extends ResultPrinter implements TestListener
 
         $testMethodName = \PHPUnit\Util\Test::describe($test);
 
+        // Convert non-breaking method name to camelCase
+        $testMethodName[1] = str_replace(' ', '', ucwords($testMethodName[1], ' '));
+        
         // Convert snakeCase method name to camelCase
         $testMethodName[1] = str_replace('_', '', ucwords($testMethodName[1], '_'));
         

--- a/tests/Output.php
+++ b/tests/Output.php
@@ -40,4 +40,9 @@ class OutputTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue(true);
     }
+
+    public function test should convert non breaking spaces to lowercased words()
+    {
+        $this->assertTrue(true);
+    }
 }

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -53,6 +53,13 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('✓ should convert snake case to lowercased words', $lines[10]);
     }
 
+    public function testTestNameCanBeNonBreakingSpaced()
+    {
+        $lines = $this->getOutput();
+
+        $this->assertStringContainsString('✓ should convert non breaking spaces to lowercased words', $lines[11]);
+    }
+
     private function getOutput(): array
     {
         $command = [


### PR DESCRIPTION
[closes #21]

This change would allow a function name with non-breaking spaces to display correctly in pretty print output.