### PR TITLE
Add ability to print the progress of running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,16 @@ Optionally, you can add it to your project's `phpunit.xml` file instead:
 
 <img src="https://raw.githubusercontent.com/Sempro/phpunit-pretty-print/master/preview.gif" width="100%" alt="phpunit-pretty-print">
 
+### Optional
+
+To view progress while tests are running you can set `PHPUNIT_PRETTY_PRINT_PROGRESS=true` as environment variable on your server or within your `phpunit.xml` config file.
+```xml
+<phpunit>
+    <php>
+        <env name="PHPUNIT_PRETTY_PRINT_PROGRESS" value="true" />
+    </php>
+</phpunit>
+```
+
 ### License
 MIT © [Sempro AS](http://www.sempro.no)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,5 +16,6 @@
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="PHPUNIT_PRETTY_PRINT_PROGRESS" value="false" />
     </php>
 </phpunit>

--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -111,6 +111,8 @@ class PrettyPrinter extends ResultPrinter implements TestListener
 
         $this->previousClassName = $this->className;
 
+        $this->printProgress();
+
         switch (strtoupper(preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $progress))) {
             case '.':
                 $this->writeWithColor('fg-green', '  ✓', false);
@@ -192,5 +194,17 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         }
 
         return $name . ' [' . $dataSetMatch[1] . ']';
+    }
+
+    private function printProgress()
+    {
+        if (filter_var(getenv('PHPUNIT_PRETTY_PRINT_PROGRESS'), FILTER_VALIDATE_BOOLEAN)) {
+            $this->numTestsRun++;
+
+            $total = $this->numTests;
+            $current = str_pad($this->numTestsRun, strlen($total), '0', STR_PAD_LEFT);
+
+            $this->write("[{$current}/{$total}]");
+        }
     }
 }

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -74,6 +74,18 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('✓ 123 can start or end with numbers 456', $lines[13]);
     }
 
+    public function testItCanShowProgressWhileRunningTests()
+    {
+        putenv('PHPUNIT_PRETTY_PRINT_PROGRESS=true');
+
+        $lines = array_slice($this->getOutput(), 4, 10);
+        $count = count($lines);
+
+        foreach ($lines as $index => $line) {
+            $this->assertStringContainsString(vsprintf('%s/%s', [$index+1, $count]), $line);
+        }
+    }
+
     private function getOutput(): array
     {
         $command = [
@@ -83,7 +95,7 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
         ];
 
         exec(implode(' ', $command), $out);
-        
+
         return $out;
     }
 }


### PR DESCRIPTION
This PR adds the ability to print the progress while the tests are still running discussed here #25 . The repository README.md is updated with an explanation of how to enable the feature.

![](https://d.pr/i/wdPjKA+) 