### PR TITLE
Preserve capitalized words

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -31,6 +31,9 @@ class PrettyPrinter extends ResultPrinter implements TestListener
 
         $testMethodName = \PHPUnit\Util\Test::describe($test);
 
+        // Convert capitalized words to lowercase
+        $testMethodName[1] = preg_replace_callback('/([A-Z]{2,})/', function ($matches) { return strtolower($matches[0]); }, $testMethodName[1]);
+
         // Convert non-breaking method name to camelCase
         $testMethodName[1] = str_replace(' ', '', ucwords($testMethodName[1], ' '));
 

--- a/tests/Output.php
+++ b/tests/Output.php
@@ -55,4 +55,9 @@ class OutputTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue(true);
     }
+
+    public function test_should_preserve_CAPITALIZED_and_paRTiaLLY_CAPitaLIZed_words()
+    {
+        $this->assertTrue(true);
+    }
 }

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -74,11 +74,18 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('✓ 123 can start or end with numbers 456', $lines[13]);
     }
 
+    public function testTestNameCanContainCapitalizedWords()
+    {
+        $lines = $this->getOutput();
+
+        $this->assertStringContainsString('✓ should preserve capitalized and partially capitalized words', $lines[14]);
+    }
+
     public function testItCanShowProgressWhileRunningTests()
     {
         putenv('PHPUNIT_PRETTY_PRINT_PROGRESS=true');
 
-        $lines = array_slice($this->getOutput(), 4, 10);
+        $lines = array_slice($this->getOutput(), 4, 11);
         $count = count($lines);
 
         foreach ($lines as $index => $line) {


### PR DESCRIPTION
Currently, if the test name contains capitalized words, they don't make it to the output. This PR fixes that:

**Before:**
> `test_should_preserve_CAPITALIZED_words` --> `should preserve words`

**After:**
> `test_should_preserve_CAPITALIZED_words` --> `should preserve capitalized words`
