### PR TITLE
Refactor the test suite to improve the test execution speed

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -32,7 +32,9 @@ class PrettyPrinter extends ResultPrinter implements TestListener
         $testMethodName = \PHPUnit\Util\Test::describe($test);
 
         // Convert capitalized words to lowercase
-        $testMethodName[1] = preg_replace_callback('/([A-Z]{2,})/', function ($matches) { return strtolower($matches[0]); }, $testMethodName[1]);
+        $testMethodName[1] = preg_replace_callback('/([A-Z]{2,})/', function ($matches) {
+            return strtolower($matches[0]);
+        }, $testMethodName[1]);
 
         // Convert non-breaking method name to camelCase
         $testMethodName[1] = str_replace(' ', '', ucwords($testMethodName[1], ' '));

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -4,79 +4,86 @@ namespace Sempro\PHPUnitPrettyPrinter\Tests;
 
 class PrinterTest extends \PHPUnit\Framework\TestCase
 {
+    private static $output;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$output = self::getOutput();
+    }
+
     public function testFirstTestShouldPass()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ success', $lines[4]);
     }
 
     public function testSecondTestShouldFail()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('x fail', $lines[5]);
     }
 
     public function testThirdTestShouldThrowAnError()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('⚈ error', $lines[6]);
     }
 
     public function testForthTestShouldBeSkipped()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('→ skip', $lines[7]);
     }
 
     public function testFifthTestShouldBeIncomplete()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('∅ incomplete', $lines[8]);
     }
 
     public function testTestNamesCanBeTitleCased()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ should convert title case to lowercased words', $lines[9]);
     }
 
     public function testTestNameCanBeSnakeCased()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ should convert snake case to lowercased words', $lines[10]);
     }
 
     public function testTestNameCanBeNonBreakingSpaced()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ should convert non breaking spaces to lowercased words', $lines[11]);
     }
 
     public function testTestNameCanContainNumbers()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ can contain 1 or 99 numbers', $lines[12]);
     }
 
     public function testTestNameCanStartOrEndWithANumber()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ 123 can start or end with numbers 456', $lines[13]);
     }
 
     public function testTestNameCanContainCapitalizedWords()
     {
-        $lines = $this->getOutput();
+        $lines = self::$output;
 
         $this->assertStringContainsString('✓ should preserve capitalized and partially capitalized words', $lines[14]);
     }
@@ -85,15 +92,15 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
     {
         putenv('PHPUNIT_PRETTY_PRINT_PROGRESS=true');
 
-        $lines = array_slice($this->getOutput(), 4, 11);
+        $lines = array_slice(self::getOutput(), 4, 11);
         $count = count($lines);
 
         foreach ($lines as $index => $line) {
-            $this->assertStringContainsString(vsprintf('%s/%s', [$index+1, $count]), $line);
+            $this->assertStringContainsString(vsprintf('%s/%s', [$index + 1, $count]), $line);
         }
     }
 
-    private function getOutput(): array
+    private static function getOutput(): array
     {
         $command = [
             "vendor/bin/phpunit",


### PR DESCRIPTION
**This pull request refactors the test suite to improve the speed. The execution time is now between 1 and 2 seconds instead of 8 or 9 seconds.**

This effect was possible by caching the output for all tests except one.