### PR TITLE
Handle tests with datasets better

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.1.0",
-        "phpunit/phpunit": ">=7.0.0 ^9.0.0"
+        "phpunit/phpunit": "^7 || ^8 || ^9"
     },
     "autoload": {
         "psr-4": {

--- a/src/PrettyPrinterTrait.php
+++ b/src/PrettyPrinterTrait.php
@@ -59,6 +59,9 @@ trait PrettyPrinterTrait
 
         // Get the data set name
         if ($dataSet) {
+            // Note: Use preg_replace() instead of trim() because the dataset may end with a quote
+            // (double quotes) and trim() would remove both from the end. This matches only a single
+            // quote from the beginning and end of the dataset that was added by PHPUnit itself.
             $name .= ' [ ' . preg_replace('/^"|"$/', '', $dataSet) . ' ]';
         }
 

--- a/src/PrettyPrinterTrait.php
+++ b/src/PrettyPrinterTrait.php
@@ -29,19 +29,23 @@ trait PrettyPrinterTrait
         parent::endTest($test, $time);
 
         $testMethodName = \PHPUnit\Util\Test::describe($test);
+        
+        $parts = preg_split('/ with data set /', $testMethodName[1]);
+        $methodName = array_shift($parts);
+        $dataSet = array_shift($parts);
 
         // Convert capitalized words to lowercase
-        $testMethodName[1] = preg_replace_callback('/([A-Z]{2,})/', function ($matches) {
+        $methodName = preg_replace_callback('/([A-Z]{2,})/', function ($matches) {
             return strtolower($matches[0]);
-        }, $testMethodName[1]);
+        }, $methodName);
 
         // Convert non-breaking method name to camelCase
-        $testMethodName[1] = str_replace(' ', '', ucwords($testMethodName[1], ' '));
+        $methodName = str_replace(' ', '', ucwords($methodName, ' '));
 
         // Convert snakeCase method name to camelCase
-        $testMethodName[1] = str_replace('_', '', ucwords($testMethodName[1], '_'));
+        $methodName = str_replace('_', '', ucwords($methodName, '_'));
 
-        preg_match_all('/((?:^|[A-Z])[a-z0-9]+)/', $testMethodName[1], $matches);
+        preg_match_all('/((?:^|[A-Z])[a-z0-9]+)/', $methodName, $matches);
 
         // Prepend all numbers with a space
         $replaced = preg_replace('/(\d+)/', ' $1', $matches[0]);
@@ -54,7 +58,9 @@ trait PrettyPrinterTrait
         $name = preg_replace('/^test /', '', $name, 1);
 
         // Get the data set name
-        $name = $this->handleDataSetName($name, $testMethodName[1]);
+        if ($dataSet) {
+            $name .= ' [ ' . preg_replace('/^"|"$/', '', $dataSet) . ' ]';
+        }
 
         $color = 'fg-green';
         if ($test->getStatus() !== 0) {
@@ -187,17 +193,6 @@ trait PrettyPrinterTrait
         }
 
         return $exceptionMessage;
-    }
-
-    private function handleDataSetName($name, $testMethodName): string
-    {
-        preg_match('/\bwith data set "([^"]+)"/', $testMethodName, $dataSetMatch);
-
-        if (empty($dataSetMatch)) {
-            return $name;
-        }
-
-        return $name . ' [' . $dataSetMatch[1] . ']';
     }
 
     private function printProgress()


### PR DESCRIPTION
I have noticed that sometimes the dataset label can have some rather unintentionally consequences when displaying the output.

I dug a little and found that it was because it was applying the matching and replacements to the entire match, not just the method name. Ironically, there is (was) a method included here that was seemingly supposed to help with this, but it was invoked way too late; so I just removed it and appended the dataset after.

It now immediately splits the method name from the data set from the beginning so it doesn't unintentionally transform the dataset label or match against it.

**Before:**
```
[05/48]  ✓ configuration [locale: ] [0.005s]
[06/48]  ✓ configuration [locale: ] [0.005s]
[07/48]  ✓ configuration [locale: ] [0.005s]
[08/48]  ✓ configuration us [locale: ] [0.009s]
[09/48]  ✓ configuration us [locale: ] [0.012s]
[10/48]  ✓ configuration [locale: ] [0.005s]
[11/48]  ✓ configuration [locale: ] [0.003s]
[12/48]  ✓ configuration bar [locale: ] [0.003s]
[13/48]  ✓ configuration [locale: ] [0.007s]
[14/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.012s]
[15/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.004s]
[16/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.004s]
[17/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.004s]
[18/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.011s]
[19/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.007s]
[20/48]  ✓ configuration shortcodes [excludeShortcodes: ] [0.004s]
[21/48]  ✓ configuration shortcodes foo bar [excludeShortcodes: ] [0.004s]
[22/48]  ✓ configuration shortcodes [excludeShortcodes: [] [0.004s]
[23/48]  ✓ configuration [preset: ] [0.007s]
[24/48]  ✓ configuration [preset: ] [0.012s]
[25/48]  ✓ configuration [preset: ] [0.004s]
[26/48]  ✓ configuration [preset: ] [0.004s]
[27/48]  ✓ configuration [preset: ] [0.004s]
[28/48]  ✓ configuration [preset: ] [0.004s]
[29/48]  ✓ configuration [preset: ] [0.012s]
[30/48]  ✓ configuration [preset: ] [0.006s]
[31/48]  ✓ configuration [preset: ] [0.004s]
[32/48]  ✓ configuration [preset: ] [0.004s]
[33/48]  ✓ configuration bar [preset: ] [0.004s]
[34/48]  ✓ configuration [preset: ] [0.004s]
```


**After:**
```
[05/48]  ✓ configuration [ locale: "en" ] [0.006s]
[06/48]  ✓ configuration [ locale: "EN" ] [0.005s]
[07/48]  ✓ configuration [ locale: "en-US" ] [0.005s]
[08/48]  ✓ configuration [ locale: "en_US" ] [0.005s]
[09/48]  ✓ configuration [ locale: "EN_us" ] [0.016s]
[10/48]  ✓ configuration [ locale: "EN-US" ] [0.005s]
[11/48]  ✓ configuration [ locale: "100-134" ] [0.006s]
[12/48]  ✓ configuration [ locale: "foo_bar" ] [0.004s]
[13/48]  ✓ configuration [ locale: "english" ] [0.004s]
[14/48]  ✓ configuration [ excludeShortcodes: ":" ] [0.004s]
[15/48]  ✓ configuration [ excludeShortcodes: "foo bar" ] [0.004s]
[16/48]  ✓ configuration [ excludeShortcodes: "foo:bar" ] [0.004s]
[17/48]  ✓ configuration [ excludeShortcodes: ":foo-bar:" ] [0.005s]
[18/48]  ✓ configuration [ excludeShortcodes: "(FOO bar)" ] [0.005s]
[19/48]  ✓ configuration [ excludeShortcodes: "[foo:BAR]" ] [0.004s]
[20/48]  ✓ configuration [ excludeShortcodes: "{foo bar}" ] [0.004s]
[21/48]  ✓ configuration [ excludeShortcodes: "Foo_Bar" ] [0.004s]
[22/48]  ✓ configuration [ excludeShortcodes: ["foo bar", "foo:bar"] ] [0.007s]
[23/48]  ✓ configuration [ preset: "cldr" ] [0.004s]
[24/48]  ✓ configuration [ preset: "cldr-native" ] [0.005s]
[25/48]  ✓ configuration [ preset: "emojibase" ] [0.004s]
[26/48]  ✓ configuration [ preset: "emojibase-legacy" ] [0.004s]
[27/48]  ✓ configuration [ preset: "github" ] [0.011s]
[28/48]  ✓ configuration [ preset: "iamcal" ] [0.004s]
[29/48]  ✓ configuration [ preset: "joypixels" ] [0.004s]
[30/48]  ✓ configuration [ preset: "discord" ] [0.004s]
[31/48]  ✓ configuration [ preset: "slack" ] [0.004s]
[32/48]  ✓ configuration [ preset: "100-134" ] [0.004s]
[33/48]  ✓ configuration [ preset: "foo_bar" ] [0.011s]
[34/48]  ✓ configuration [ preset: "english" ] [0.004s]
```
