### PR TITLE
Fix bad formatting of named datasets with capitals

### DIFF
--- a/tests/Output.php
+++ b/tests/Output.php
@@ -60,4 +60,20 @@ class Output extends \PHPUnit\Framework\TestCase
     {
         $this->assertTrue(true);
     }
+
+    public function dataProvider()
+    {
+        yield 'dataset1' => ['test'];
+        yield 'DataSet2' => ['test'];
+        yield 'data set 3' => ['test'];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testWithNamedDatasets(string $value)
+    {
+        $this->assertEquals('test', $value);
+    }
+
 }

--- a/tests/PrinterTest.php
+++ b/tests/PrinterTest.php
@@ -85,12 +85,23 @@ class PrinterTest extends \PHPUnit\Framework\TestCase
     {
         putenv('PHPUNIT_PRETTY_PRINT_PROGRESS=true');
 
-        $lines = array_slice($this->getOutput(), 4, 11);
+        $lines = array_slice($this->getOutput(), 4, 14);
         $count = count($lines);
 
         foreach ($lines as $index => $line) {
             $this->assertStringContainsString(vsprintf('%s/%s', [$index+1, $count]), $line);
         }
+
+        putenv('PHPUNIT_PRETTY_PRINT_PROGRESS=false');
+    }
+
+    public function testItShowsDatasetName()
+    {
+        $lines = $this->getOutput();
+
+        $this->assertStringContainsString('✓ with named datasets [dataset1]', $lines[15]);
+        $this->assertStringContainsString('✓ with named datasets [DataSet2]', $lines[16]);
+        $this->assertStringContainsString('✓ with named datasets [data set 3]', $lines[17]);
     }
 
     private function getOutput(): array


### PR DESCRIPTION
This commit fixes the data set name being printed twice when the name
of the data set contains upper case characters.

Also created a unit test to demonstrate the behaviour. Without this fix:

```
1) Sempro\PHPUnitPrettyPrinter\Tests\PrinterTest::testItShowsDatasetName
Failed asserting that '  ✓ with named datasets data set 2 [DataSet2] [0.000s]' contains "✓ with named datasets [DataSet2]".
```

The test now passes.

Fixes #42