### PR TITLE
Document fix for PHPUnit 9 compat

### DIFF
--- a/src/PrettyPrinter.php
+++ b/src/PrettyPrinter.php
@@ -5,6 +5,13 @@ namespace Sempro\PHPUnitPrettyPrinter;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\TextUI\ResultPrinter;
 
+/**
+ * For PHPUnit9 you must use instead {@see PrettyPrinterForPhpUnit9}
+ *
+ * @deprecated 1.4.0
+ *
+ * @link https://github.com/indentno/phpunit-pretty-print/issues/32 Fix for PHPUnit9 compatibility
+ */
 class PrettyPrinter extends ResultPrinter implements TestListener
 {
     use PrettyPrinterTrait;


### PR DESCRIPTION
Add PHPDoc block for the PrettyPrinter, to explain it must be replaced when using PHPUnit 9.

See #32.